### PR TITLE
[feat] summoners api에 대해 CORS 설정 추가

### DIFF
--- a/src/main/kotlin/com/sota/clone/copyopgg/web/WebConfig.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/web/WebConfig.kt
@@ -1,6 +1,7 @@
 package com.sota.clone.copyopgg.web
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -10,5 +11,10 @@ class WebConfig: WebMvcConfigurer {
 
     override fun addViewControllers(registry: ViewControllerRegistry) {
         registry.addViewController("/swagger").setViewName("/swagger/index.html")
+    }
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/api/summoners/**")
+            .allowedOrigins("*")
     }
 }


### PR DESCRIPTION
* Web Config 파일에 CORS 설정하는 메서드 추가
* 현재 /api/summoners/ 하위의 모든 api 요청에 대해서, Origin과 무관하게 요청을 받을 수 있도록 설정