### PR TITLE
application.yaml 수정 및 getSummonerInfo api 리턴타입 변경

### DIFF
--- a/src/main/kotlin/com/sota/clone/copyopgg/controllers/SummonerController.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/controllers/SummonerController.kt
@@ -33,30 +33,40 @@ class SummonerController(
     @GetMapping("/profile-info/{searchWord}")
     fun getSummonerInfo(@PathVariable(name = "searchWord", required = true) searchWord: String): SummonerBriefInfo {
         logger.info("Searching for summoner information named '$searchWord'")
-        var result = summonerRepo.searchByName(searchWord)
+        val result = summonerRepo.searchByName(searchWord)
 
-        if (result == null) {
+        return if (result == null) {
             logger.info("Not in DB, search via riot api, key: " + System.getenv("RIOT_API_KEY"))
             val summoner = Orianna.summonerNamed(searchWord).withRegion(Region.KOREA).get()
-            summonerRepo.insertSummoner(SummonerDTO(
-                accountId = summoner.accountId,
-                puuid = summoner.puuid,
-                id = summoner.id,
-                name = summoner.name,
-                summonerLevel = summoner.level.toLong(),
-                profileIconId = summoner.profileIcon.id,
-                revisionDate = summoner.updated.millis
-            ))
-            result = SummonerBriefInfo(
-                id = summoner.id,
-                name = summoner.name,
-                profileIconId = summoner.profileIcon.id,
-                summonerLevel = summoner.level.toLong(),
-                leagueInfo = null
-            )
-        }
 
-        return result
+            if (summoner.puuid == null) SummonerBriefInfo(
+                id = "",
+                name = "",
+                profileIconId = -1,
+                summonerLevel = -1,
+                leagueInfo = null
+            ) else {
+                summonerRepo.insertSummoner(
+                    SummonerDTO(
+                        accountId = summoner.accountId,
+                        puuid = summoner.puuid,
+                        id = summoner.id,
+                        name = summoner.name,
+                        summonerLevel = summoner.level.toLong(),
+                        profileIconId = summoner.profileIcon.id,
+                        revisionDate = summoner.updated.millis
+                    )
+                )
+
+                SummonerBriefInfo(
+                    id = summoner.id,
+                    name = summoner.name,
+                    profileIconId = summoner.profileIcon.id,
+                    summonerLevel = summoner.level.toLong(),
+                    leagueInfo = null
+                )
+            }
+        } else result
     }
 
     //테스트용

--- a/src/main/kotlin/com/sota/clone/copyopgg/models/Summoners.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/models/Summoners.kt
@@ -27,14 +27,6 @@ data class LeagueInfo(
     val leaguePoints: Int
 )
 
-// data class for get-summoners-info response
-data class SummonerProfileInfo(
-    val puuid: String,
-    val name: String,
-    val summonerLevel: Long,
-    val profileIconId: Int
-)
-
 data class LeagueSummoner(
     val summonerId: String,
     val leagueId: String,

--- a/src/main/kotlin/com/sota/clone/copyopgg/repositories/RepositoryUtils.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/repositories/RepositoryUtils.kt
@@ -1,0 +1,12 @@
+package com.sota.clone.copyopgg.repositories
+
+import java.sql.ResultSet
+
+fun columnExistsInResultSet(rs: ResultSet, columnLabel: String): Boolean {
+    for (i: Int in 1..rs.metaData.columnCount) {
+        val columnName = rs.metaData.getColumnName(i)
+        if (columnLabel == columnName) return true
+    }
+
+    return false
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 spring:
   datasource:
-    url:
-    username:
-    password:
+    url: ${COPY_OPGG_DATASOURCE_URL}
+    username: ${COPY_OPGG_DATASOURCE_USERNAME}
+    password: ${COPY_OPGG_DATASOURCE_PASSWORD}

--- a/src/main/resources/static/opgg-clone-apis.yaml
+++ b/src/main/resources/static/opgg-clone-apis.yaml
@@ -47,7 +47,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/summoner-profile-info'
+                $ref: '#/components/schemas/SummonerBriefInfo'
 components:
   schemas:
     SummonerBriefInfo:
@@ -102,19 +102,6 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/SummonerBriefInfo'
-    summoner-profile-info:
-      required:
-        - puuid
-      properties:
-        puuid:
-          type: string
-        name:
-          type: string
-        summonerLevel:
-          type: integer
-          format: int64
-        profileIconId:
-          type: integer
     Error:
       required:
         - code


### PR DESCRIPTION
- application.yaml의 datasource를 환경변수로부터 가져오도록 변경
- getSummonerInfo API의 리턴타입을 SummonerProfileInfo에서 SummonerBriefInfo로 변경
- SummonerProfileInfo 타입 삭제
- 검색결과 없을 때의 exception handling 추가