### PR TITLE
add queueType in response of getBriefLeagueInfo api

### DIFF
--- a/src/main/kotlin/com/sota/clone/copyopgg/domain/models/LeagueSummoner.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/domain/models/LeagueSummoner.kt
@@ -20,4 +20,5 @@ data class LeagueBriefInfoBySummoner(
     val tier: Tier?,
     val rank: Rank?,
     val leagueName: String,
+    val queueType: String,
 )

--- a/src/main/kotlin/com/sota/clone/copyopgg/domain/repositories/LeagueSummonerRepository.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/domain/repositories/LeagueSummonerRepository.kt
@@ -4,9 +4,10 @@ import com.sota.clone.copyopgg.domain.models.LeagueSummoner
 
 interface LeagueSummonerRepository {
     fun existsLeagueSummonerBySummoner(summonerId: String): Boolean
+    fun existsLeagueSummonerBySummonerAndLeague(summonerId: String, leagueId: String): Boolean
     fun insertLeagueSummoners(leagueSummoners: List<LeagueSummoner>)
     fun insertLeagueSummoner(leagueSummoner: LeagueSummoner)
     fun updateLeagueSummonerBySummoner(leagueSummoner: LeagueSummoner)
     fun syncLeagueSummoner(leagueSummoner: LeagueSummoner)
-    fun getLeagueSummonerBySummonerId(summonerId: String): LeagueSummoner?
+    fun getLeagueSummonerBySummonerId(summonerId: String): Array<LeagueSummoner>
 }

--- a/src/main/kotlin/com/sota/clone/copyopgg/domain/services/RiotApiService.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/domain/services/RiotApiService.kt
@@ -40,15 +40,13 @@ class RiotApiService {
         }
     }
 
-    fun getLeagueSummoner(summonerId: String): LeagueSummoner? {
+    fun getLeagueSummoner(summonerId: String): Array<LeagueSummoner>? {
         return try {
             apiKey?.run {
                 restTemplate.getForObject(
                     "$apiRootUrl/lol/league/v4/entries/by-summoner/$summonerId?api_key=$this",
                     Array<LeagueSummoner>::class.java
-                )?.run {
-                    this[0]
-                }
+                )
             }
         } catch (e: Exception) {
             logger.error("error occurred when using riot api", e)

--- a/src/main/kotlin/com/sota/clone/copyopgg/web/rest/SummonerController.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/web/rest/SummonerController.kt
@@ -67,33 +67,36 @@ class SummonerController(
             name = "searchId",
             required = true
         ) searchId: String
-    ): ResponseEntity<LeagueBriefInfoBySummoner> {
+    ): ResponseEntity<List<LeagueBriefInfoBySummoner?>> {
         logger.info("Get league brief information with summoner id: $searchId")
-        return this.leagueSummonerRepo.getLeagueSummonerBySummonerId(searchId)?.let { leagueSummoner ->
-            this.leagueRepo.findLeagueById(leagueSummoner.leagueId)?.let { league ->
-                ResponseEntity.ok().body(
+        return ResponseEntity.ok().body(
+            this.leagueSummonerRepo.getLeagueSummonerBySummonerId(searchId).map {
+                this.leagueRepo.findLeagueById(it.leagueId)?.let { league ->
                     LeagueBriefInfoBySummoner(
                         tier = league.tier,
-                        wins = leagueSummoner.wins,
-                        loses = leagueSummoner.losses,
-                        leaguePoints = leagueSummoner.leaguePoints,
+                        wins = it.wins,
+                        loses = it.losses,
+                        leaguePoints = it.leaguePoints,
                         leagueName = league.name,
-                        rank = leagueSummoner.rank
+                        rank = it.rank,
+                        queueType = league.queue.toString()
                     )
-                )
-            } ?: ResponseEntity.notFound().build()
-        } ?: ResponseEntity.notFound().build()
+                }
+            }
+        )
     }
 
     @GetMapping("/refresh/{summonerId}")
     fun refresh(@PathVariable(name = "summonerId", required = true) summonerId: String): ResponseEntity<BooleanResponse> {
         logger.info("Synchronize data of summoner has id $summonerId")
-        val result = this.riotApiController.getLeagueSummoner(summonerId)?.let { leagueSummoner ->
-            this.riotApiController.getLeague(leagueSummoner.leagueId)?.let { league ->
-                this.leagueSummonerRepo.syncLeagueSummoner(leagueSummoner)
-                this.leagueRepo.syncLeague(league)
-                true
-            } ?: false
+        val result = this.riotApiController.getLeagueSummoner(summonerId)?.let { leagueSummoners ->
+            leagueSummoners.forEach { leagueSummoner ->
+                this.riotApiController.getLeague(leagueSummoner.leagueId)?.let { league ->
+                    this.leagueSummonerRepo.syncLeagueSummoner(leagueSummoner)
+                    this.leagueRepo.syncLeague(league)
+                }
+            }
+            true
         } ?: false
         return ResponseEntity.ok().body(
             BooleanResponse(

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -40,7 +40,7 @@ create table if not exists league_summoner (
   league_points integer not null,
   league_id char(36) not null,
   summoner_id varchar(63) not null,
-  primary key("summoner_id")
+  primary key ("league_id", "summoner_id")
 );
 
 create table if not exists matches (

--- a/src/main/resources/static/opgg-clone-apis.yaml
+++ b/src/main/resources/static/opgg-clone-apis.yaml
@@ -67,7 +67,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SummonerLeagueBriefInfo'
+                type: array
+                items:
+                  $ref: '#/components/schemas/SummonerLeagueBriefInfo'
   /api/summoners/refresh/{summonerId}:
     get:
       summary: Get brief league information with summoner's id
@@ -140,6 +142,7 @@ components:
         - tier
         - rank
         - leagueName
+        - queueType
       properties:
         wins:
           type: integer
@@ -156,6 +159,8 @@ components:
           format: int32
         leagueName:
           type: string
+        queueType:
+          $ref: '#/components/schemas/QueueType'
     Tier:
       type: string
       enum:
@@ -175,6 +180,12 @@ components:
         - II
         - III
         - IV
+    QueueType:
+      type: string
+      enum:
+        - RANKED_SOLO_5x5
+        - RANKED_FLEX_SR
+        - RANKED_FLEX_TT
     Summoners:
       type: array
       items:


### PR DESCRIPTION
- response type list로 변경
- DB에서 league_summoner table의 primary key 복합키로 변경
- league_summoner에 write, read 할 때 queueType의 수 만큼 반복적으로 수행