### PR TITLE
bugfix: Docker build error fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
+FROM gradle:7.4.2-jdk8 AS builder
+WORKDIR /build
+ADD build.gradle.kts settings.gradle.kts /build/
+RUN gradle build -x test --parallel --continue > /dev/null 2>&1 || true
+
+COPY . /build
+RUN gradle clean build -x test --parallel
+
 FROM openjdk:8-jdk-alpine
-ARG JAR_FILE=./build/libs/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+WORKDIR /app
+ARG JAR_FILE=/build/build/libs/*.jar
+COPY --from=builder ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
- 기존 Dockerfiledp spring을 실행하기 위한 java 명령어만 포함되어있었음
    - gradle build 후에만 실행이 가능했던 상황
- gradle 또한 docker에 포함시켜 빌드도 docker로 되도록 수정
- 최초에 sql create type 하도록 sql 수정은 필요해보임
    - create type if not exist 문법은 따로 없어 방법 시도해봤는데 잘 안됨