### PR TITLE
refactor: api response data to dto

### DIFF
--- a/src/main/kotlin/com/sota/clone/copyopgg/domain/services/MatchService.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/domain/services/MatchService.kt
@@ -8,6 +8,7 @@ import com.sota.clone.copyopgg.domain.repositories.MatchRepository
 import com.sota.clone.copyopgg.domain.repositories.MatchSummonerRepository
 import com.sota.clone.copyopgg.domain.repositories.MatchTeamRepository
 import com.sota.clone.copyopgg.domain.repositories.SummonerChampionStatisticsRepository
+import com.sota.clone.copyopgg.web.dto.match.MatchSummaryDTO
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,35 +26,29 @@ class MatchService(
     val logger: Logger = LoggerFactory.getLogger(MatchService::class.java)
 ) {
 
-    fun getMatchSummariesByPuuid(puuid: String, page: Int, pageSize: Int): List<Map<String, Any?>> {
+    fun getMatchSummariesByPuuid(puuid: String, page: Int, pageSize: Int): List<MatchSummaryDTO> {
         val pageable: Pageable = PageRequest.of(page, pageSize)
         val matchSummoners = matchSummonerRepo.findByPuuid(puuid, pageable)
 
-
-        return List(matchSummoners.size) {
-            val matchSummoner = matchSummoners[it]
-            try {
-                mapOf(
-                    "champion" to matchSummoner.matchSummonerChampion!!.championId,
-                    "spell1" to matchSummoner.matchSummonerChampion!!.summoner1Id,
-                    "spell2" to matchSummoner.matchSummonerChampion!!.summoner2Id,
-                    "kills" to matchSummoner.matchSummonerCombat!!.kills,
-                    "deaths" to matchSummoner.matchSummonerCombat!!.deaths,
-                    "assists" to matchSummoner.matchSummonerCombat!!.assists,
-                    "level" to matchSummoner.matchSummonerChampion!!.champLevel,
-                    "cs" to matchSummoner.matchSummonerObjective!!.totalMinionsKilled!! + matchSummoner.matchSummonerObjective!!.neutralMinionsKilled!!,
-                    "item0" to matchSummoner.matchSummonerItem!!.item0,
-                    "item1" to matchSummoner.matchSummonerItem!!.item1,
-                    "item2" to matchSummoner.matchSummonerItem!!.item2,
-                    "item3" to matchSummoner.matchSummonerItem!!.item3,
-                    "item4" to matchSummoner.matchSummonerItem!!.item4,
-                    "item5" to matchSummoner.matchSummonerItem!!.item5,
-                    "item6" to matchSummoner.matchSummonerItem!!.item6,
-                    "detectorWardsPlaced" to matchSummoner.matchSummonerVision!!.detectorWardsPlaced,
-                )
-            } catch (e: Error) {
-                mapOf()
-            }
+        return matchSummoners.map { matchSummoner ->
+            MatchSummaryDTO(
+                champion = matchSummoner.matchSummonerChampion!!.championId,
+                spell1 = matchSummoner.matchSummonerChampion!!.summoner1Id,
+                spell2 = matchSummoner.matchSummonerChampion!!.summoner2Id,
+                kills = matchSummoner.matchSummonerCombat!!.kills,
+                deaths = matchSummoner.matchSummonerCombat!!.deaths,
+                assists = matchSummoner.matchSummonerCombat!!.assists,
+                level = matchSummoner.matchSummonerChampion!!.champLevel,
+                cs = matchSummoner.matchSummonerObjective!!.totalMinionsKilled!! + matchSummoner.matchSummonerObjective!!.neutralMinionsKilled!!,
+                item0 = matchSummoner.matchSummonerItem!!.item0,
+                item1 = matchSummoner.matchSummonerItem!!.item1,
+                item2 = matchSummoner.matchSummonerItem!!.item2,
+                item3 = matchSummoner.matchSummonerItem!!.item3,
+                item4 = matchSummoner.matchSummonerItem!!.item4,
+                item5 = matchSummoner.matchSummonerItem!!.item5,
+                item6 = matchSummoner.matchSummonerItem!!.item6,
+                detectorWardsPlaced = matchSummoner.matchSummonerVision!!.detectorWardsPlaced,
+            )
         }
     }
 

--- a/src/main/kotlin/com/sota/clone/copyopgg/domain/services/SummonerService.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/domain/services/SummonerService.kt
@@ -9,6 +9,7 @@ import com.sota.clone.copyopgg.domain.repositories.SummonerChampionStatisticsRep
 import com.sota.clone.copyopgg.domain.repositories.SummonerRepository
 import com.sota.clone.copyopgg.web.dto.summoners.QueueInfoDTO
 import com.sota.clone.copyopgg.web.dto.summoners.SummonerDTO
+import com.sota.clone.copyopgg.web.dto.summoners.SummonerInfoDTO
 import com.sota.clone.copyopgg.web.dto.summoners.SummonerChampionStatisticsDTO
 import com.sota.clone.copyopgg.web.dto.summoners.SummonerChampionStatisticsQueueDTO
 import org.slf4j.LoggerFactory
@@ -26,33 +27,31 @@ class SummonerService(
 ) {
     val logger = LoggerFactory.getLogger(SummonerService::class.java)
 
-    fun getFiveSummonersMatchedPartialName(partialName: String): List<SummonerDTO> {
+    fun getFiveSummonersMatchedPartialName(partialName: String): List<SummonerInfoDTO> {
         logger.info("getFiveSummonersMatchedPartialName called")
         var list = this.summonerRepo.findSummonersByPartialName(partialName, 5)
         return list.map {
-            SummonerDTO(
-                accountId = it.accountId,
-                profileIconId = it.profileIconId,
-                revisionDate = it.revisionDate,
-                name = it.name,
+            SummonerInfoDTO(
                 id = it.id,
                 puuid = it.puuid,
-                summonerLevel = it.summonerLevel
+                name = it.name,
+                profileIconId = it.profileIconId,
+                summonerLevel = it.summonerLevel,
+                leagueInfo = null,
             )
         }
     }
 
-    fun getSummonerByName(name: String): SummonerDTO? {
+    fun getSummonerByName(name: String): SummonerInfoDTO? {
         logger.info("getSummonerByName called")
         return this.summonerRepo.findByName(name)?.let {
-            SummonerDTO(
-                accountId = it.accountId,
-                profileIconId = it.profileIconId,
-                revisionDate = it.revisionDate,
-                name = it.name,
+            SummonerInfoDTO(
                 id = it.id,
                 puuid = it.puuid,
-                summonerLevel = it.summonerLevel
+                name = it.name,
+                profileIconId = it.profileIconId,
+                summonerLevel = it.summonerLevel,
+                leagueInfo = null,
             )
         } ?: riotApiService.getSummoner(name)?.let {
             this.summonerRepo.save(
@@ -66,7 +65,14 @@ class SummonerService(
                     summonerLevel = it.summonerLevel!!
                 )
             )
-            it
+            SummonerInfoDTO(
+                id = it.id,
+                puuid = it.puuid,
+                name = it.name,
+                profileIconId = it.profileIconId,
+                summonerLevel = it.summonerLevel,
+                leagueInfo = null,
+            )
         }
     }
 

--- a/src/main/kotlin/com/sota/clone/copyopgg/web/rest/MatchController.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/web/rest/MatchController.kt
@@ -3,6 +3,7 @@ package com.sota.clone.copyopgg.web.rest
 import com.sota.clone.copyopgg.domain.entities.Match
 import com.sota.clone.copyopgg.domain.services.MatchService
 import com.sota.clone.copyopgg.domain.services.RiotApiService
+import com.sota.clone.copyopgg.web.dto.match.MatchSummaryDTO
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -21,11 +22,11 @@ class MatchController(
         @PathVariable(value = "puuid") puuid: String,
         @RequestParam(value = "page", required = true) page: Int,
         @RequestParam(value = "pageSize", required = true, defaultValue = "20") pageSize: Int
-    ): ResponseEntity<Any> {
+    ): ResponseEntity<List<MatchSummaryDTO>> {
         return try {
             ResponseEntity.ok(matchService.getMatchSummariesByPuuid(puuid, page, pageSize))
         } catch (e: Error) {
-            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(-1)
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(listOf())
         }
     }
 

--- a/src/main/kotlin/com/sota/clone/copyopgg/web/rest/SummonerController.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/web/rest/SummonerController.kt
@@ -6,11 +6,13 @@ import com.sota.clone.copyopgg.domain.services.RiotApiService
 import com.sota.clone.copyopgg.domain.services.SummonerService
 import com.sota.clone.copyopgg.domain.services.SynchronizeService
 import com.sota.clone.copyopgg.web.dto.summoners.QueueInfoDTO
+import com.sota.clone.copyopgg.web.dto.summoners.SummonerInfoDTO
 import com.sota.clone.copyopgg.web.dto.summoners.SummonerChampionStatisticsQueueDTO
 import io.swagger.annotations.ApiOperation
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -29,17 +31,12 @@ class SummonerController(
             name = "searchWord",
             required = true
         ) searchWord: String
-    ): Iterable<Map<String, Any?>> {
+    ): ResponseEntity<List<SummonerInfoDTO>> {
         logger.info("Searching for summoner names that start with '$searchWord'")
-        return this.summonerService.getFiveSummonersMatchedPartialName(searchWord).map {
-            mapOf(
-                "id" to it.id,
-                "puuid" to it.puuid,
-                "name" to it.name,
-                "profileIconId" to it.profileIconId,
-                "summonerLevel" to it.summonerLevel,
-                "leagueInfo" to null
-            )
+        return try {
+            ResponseEntity.ok(summonerService.getFiveSummonersMatchedPartialName(searchWord))
+        } catch (e: Error) {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(listOf())
         }
     }
 
@@ -49,19 +46,10 @@ class SummonerController(
             name = "searchWord",
             required = true
         ) searchWord: String
-    ): ResponseEntity<Map<String, Any?>> {
+    ): ResponseEntity<SummonerInfoDTO> {
         logger.info("Searching for summoner information named '$searchWord'")
         return this.summonerService.getSummonerByName(searchWord)?.let {
-            ResponseEntity.ok().body(
-                mapOf(
-                    "id" to it.id,
-                    "puuid" to it.puuid,
-                    "name" to it.name,
-                    "profileIconId" to it.profileIconId,
-                    "summonerLevel" to it.summonerLevel,
-                    "leagueInfo" to null
-                )
-            )
+            ResponseEntity.ok().body(it)
         } ?: ResponseEntity.notFound().build()
     }
 


### PR DESCRIPTION
- response를 map으로 작성하여 swagger example에 제대로 나타나지 않던 문제 해결
- SummonerInfoDto의 leagueInfo를 LeagueDTO로 했는데, 기존 null로 되어있어 그대로 null로 둠
    - 추후에 값을 넣을 경우 그대로 LeagueDTO로 할 지는 생각해봐야 함
    - opgg 검색결과에서는 tier, Rank, leaguePoints만 쓰이는 것으로 보임