### PR TITLE
bugfix: match update error fix

### DIFF
--- a/src/main/kotlin/com/sota/clone/copyopgg/database/impl/MatchSummonerRepositoryImpl.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/database/impl/MatchSummonerRepositoryImpl.kt
@@ -20,4 +20,8 @@ class MatchSummonerRepositoryImpl(
         return jpaRepository.findByPuuid(puuid, pageable)
     }
 
+    override fun findByPuuidLastGame(puuid: String): MatchSummoner? {
+        return jpaRepository.findFirstByPuuidOrderByIdDesc(puuid)
+    }
+
 }

--- a/src/main/kotlin/com/sota/clone/copyopgg/database/jpa/JpaMatchSummonerRepository.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/database/jpa/JpaMatchSummonerRepository.kt
@@ -11,4 +11,6 @@ interface JpaMatchSummonerRepository : JpaRepository<MatchSummoner, Int> {
 
     fun findByPuuid(puuid: String, pageable: Pageable): List<MatchSummoner>
 
+    fun findFirstByPuuidOrderByIdDesc(puuid: String): MatchSummoner?
+
 }

--- a/src/main/kotlin/com/sota/clone/copyopgg/domain/repositories/MatchSummonerRepository.kt
+++ b/src/main/kotlin/com/sota/clone/copyopgg/domain/repositories/MatchSummonerRepository.kt
@@ -9,4 +9,6 @@ interface MatchSummonerRepository {
 
     fun findByPuuid(puuid: String, pageable: Pageable): List<MatchSummoner>
 
+    fun findByPuuidLastGame(puuid: String): MatchSummoner?
+
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -94,7 +94,7 @@ create table if not exists matches_teams_ban_info (
 create table if not exists matches_summoners (
     "id" serial,
     "match_id" char(13) references matches,
-    "puuid" char(78) references summoners,
+    "puuid" char(78),
     "game_ended_in_early_surrender" boolean not null,
     "game_ended_in_surrender" boolean not null,
     "individual_position" text not null,
@@ -211,7 +211,13 @@ create table if not exists matches_summoners_vision (
 
 create table if not exists matches_summoners_item (
     "match_summoner_id" int references matches_summoners("id"),
-    "items" int[] not null,
+    "item0" int not null,
+    "item1" int not null,
+    "item2" int not null,
+    "item3" int not null,
+    "item4" int not null,
+    "item5" int not null,
+    "item6" int not null,
     "item_purchased" int not null,
     "consumable_purchased" int not null,
     "gold_earned" int not null,


### PR DESCRIPTION
- match update시 match summoners item 테이블에 items list가 entity와 맞지 않는 문제
  - 기존 의도가 list 형태에 mapping되는 것이었더라도 item의 수가 static하기 때문에 큰 문제가 없을 것이라 판단
- match update시 로직 개선
  - 기존에 latast match를 가져올때 match repo에서 가져오고 있었는데 match entity에서는 puuid를 저장하지 않아서 findByPuuid가 불가능한 상황이었음
    - puuid를 저장하고 있는 match summoner repo를 이용함
  - riot api에서 match를 가져올 때 (최근게임,...오래된게임)순으로 가져오는데 여러번 가져올 경우 latest match를 가져올 수 없는 상황이었음
    - riot api에서 가져온 match들을 reverse하여 (오래된게임,...최근게임)순으로 저장하고, first game를 조회하지 않고 last game을 조회하도록 변경하여 해결
- match update시 match summoners 테이블에서 puuid가 summoners를 reference하면 모든 summoner들이 저장되어있어야 해서 reference를 제거함